### PR TITLE
Memo repoClient so it doesn't change every render

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { AuthContext } from '@context/AuthContext'
 import { StoreContext } from '@context/StoreContext'
@@ -41,10 +41,12 @@ export default function AppContextProvider({
     }
   } = useContext(StoreContext)
 
-  const repoClient = useRepoClient({
-    basePath: `${server}/api/v1/`,
-    token: authentication?.token?.sha1,
-  })
+  const repoClient = useMemo( () => useRepoClient({
+      basePath: `${ server }/api/v1/`,
+      token: authentication?.token?.sha1,
+    })
+  , [server, authentication])
+
 
   const _setBooks = (value) => {
     setBooks(value)


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] useRepoClient seems to not be a real hook since it always recreates the repoClient object instead of saving it to a state or something. This caused the books to be downloaded twice since repoClient is a dep on the effect that downloads the books. Each time something in app context changes a new repoClient is created which run the effect again. It should proably be update in dcs-react-hooks but memo works for now.

## Test Instructions

- [ ] Load a book and check network log to see it only downloads once.
