### PR TITLE
Remove repoClient as dep to avoid double loading

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState, useMemo } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { AuthContext } from '@context/AuthContext'
 import { StoreContext } from '@context/StoreContext'
@@ -41,12 +41,10 @@ export default function AppContextProvider({
     }
   } = useContext(StoreContext)
 
-  const repoClient = useMemo( () => useRepoClient({
-      basePath: `${ server }/api/v1/`,
-      token: authentication?.token?.sha1,
-    })
-  , [server, authentication])
-
+  const repoClient = useRepoClient({
+    basePath: `${server}/api/v1/`,
+    token: authentication?.token?.sha1,
+  })
 
   const _setBooks = (value) => {
     setBooks(value)
@@ -156,7 +154,7 @@ export default function AppContextProvider({
         getContent()
       }
     }
-  }, [authentication, owner, server, languageId, refresh, books, ltStState, ep, setBooks, setLtStState, repoClient])
+  }, [authentication, owner, server, languageId, refresh, books, ltStState, ep, setBooks, setLtStState])
 
 
   // create the value for the context provider

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { AuthContext } from '@context/AuthContext'
 import { StoreContext } from '@context/StoreContext'
@@ -41,10 +41,12 @@ export default function AppContextProvider({
     }
   } = useContext(StoreContext)
 
-  const repoClient = useRepoClient({
-    basePath: `${server}/api/v1/`,
-    token: authentication?.token?.sha1,
-  })
+  const repoClient = useMemo( () => useRepoClient({
+      basePath: `${ server }/api/v1/`,
+      token: authentication?.token?.sha1,
+    })
+  , [server, authentication])
+
 
   const _setBooks = (value) => {
     setBooks(value)


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] useRepoClient seems to not be a real hook since it always recreates the repoClient object instead of saving it to a state or something. This caused the books to be downloaded twice since repoClient is a dep on the effect that downloads the books. Each time something in app context changes a new repoClient is created which run the effect again. It should probably be update in dcs-react-hooks but removing it as dep works for now and this is how it is done in the examples.

## Test Instructions

- [ ] Load a book and check network log to see it only downloads once.
