### PR TITLE
book name lookup bug and extract id from usfm

### DIFF
--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -94,12 +94,17 @@ export default function ScriptureWorkspaceCard({
   }
   
   let title = '';
-  const idParts = id.split('-');
-  if ( BIBLE_AND_OBS[bookId] ) {
-    title += BIBLE_AND_OBS[bookId];
-    idParts.shift()
+  // const idParts = id.split('-');
+  if ( BIBLE_AND_OBS[bookId.toLowerCase()] ) {
+    title += BIBLE_AND_OBS[bookId.toLowerCase()];
+    // idParts.shift()
   }
-  title += '('+idParts.join('-')+')'
+  // title += ' ('+idParts.join('-')+')'
+  if ( data.url ) {
+    title += " (" + data.url + ")"
+  } else {
+    title += " (" + id.substr(4) + ")"
+  }
 
   return (
     <Card title={title}

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -8,6 +8,7 @@ import { decodeBase64ToUtf8 } from '@utils/base64Decode';
 import { LITERAL, SIMPLIFIED, CUSTOM } from '@common/constants';
 import { fetchFromUserBranch } from '@utils/fetchFromUserBranch';
 import { randomLetters } from '@utils/randomLetters';
+import { data } from 'autoprefixer';
 
 export const AppContext = React.createContext({});
 
@@ -125,6 +126,16 @@ export default function AppContextProvider({
             }
             _books[i].usfmText = _usfmText
             _books[i].type = ltStState
+
+            // extract bookId from text
+            const _regex = /^\\id [A-Z0-9]{3} /;
+            const _found = _usfmText.match(_regex);
+            const _textBookId = _found && _found[0] ? _found[0]?.substr(-4).trim() : null;
+            console.log("ID from USFM Text:", _textBookId);
+            // let id from usfm text take precedence
+            if ( _books[i].bookId !== _textBookId ) {
+              _books[i].bookId = _textBookId
+            }
             const _docSetId = _books[i].url ?
               "org-unk/" + randomLetters(3) + "_" + randomLetters(3)
               :


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] Ensure that bookId from USFM text itself is being used, not what might be derived from the URL
- [ ] Fixed bible name lookups when the bookId is in uppercase
- [ ] Adjusted Card title to take advantage of above
- [ ] Including using the URL for the book name qualifier in parens

## Test Instructions

- [ ] open https://git.door43.org/cecil.new/en_ult/raw/branch/master/sample.usfm
- [ ] observe that name of book is Titus and is qualified by the URL
