### PR TITLE
Show id of unknown books

### DIFF
--- a/src/common/BooksOfTheBible.js
+++ b/src/common/BooksOfTheBible.js
@@ -291,7 +291,7 @@ export function bookSelectList(books = null) {
      books = Object.keys(BIBLE_AND_OBS)
    }
   return books.map(
-    (bookId) => ({ id: bookId, name: BIBLE_AND_OBS[bookId] }),
+    (bookId) => ({ id: bookId, name: BIBLE_AND_OBS[bookId] ?? bookId }),
   )
 }
 


### PR DESCRIPTION
# Describe what your pull request addresses
fixes #86 
- [ ] Allow opening projects in manifest that don't match known bookIds

## Test Instructions

- [ ] Add book
- [ ] Go to es-419 org and es-419_glt repo
- [ ] `frt` should be first book in list
- [ ] It won't work because the manifest is incorrect but it would work if the file existed in the repo

Only downside is we don't show the full name of the book but I think our users can work with just the id.
