### PR TITLE
remove text-sm class which uses important! and will cause other issues

### DIFF
--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -109,7 +109,6 @@ export default function ScriptureWorkspaceCard({
         // ep[docSetId]?.localBookCodes().includes(bookId.toUpperCase())
         data.usfmText
         ?
-          <div className="text-sm">
           <UsfmEditor key="1"
             bookId={data.bookId}
             docSetId={docSetId}
@@ -117,7 +116,6 @@ export default function ScriptureWorkspaceCard({
             onSave={ (bookCode,usfmText) => setDoSave(usfmText) }
             editable={id.endsWith(owner) ? true : false}
           />
-          </div>
         :
         (
           typeof data.content === "string"


### PR DESCRIPTION
[For #32
](https://github.com/unfoldingWord/uw-editor/issues/32)


## Test Instructions

- [ ] Load a book with long title in gT like en_ust exo
- [ ] Resize card so title is on two line
- [ ] it should look good
- [ ] all text should look good
