### PR TITLE
disables nav and sync

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -189,7 +189,9 @@ export default function Header({
       setBooks(_books)
     }
   }
-
+  // adding this flag to disable the bible ref component
+  // for v0.9; see issue 152
+  const brFlag = false
   return (
     <header>
       <AppBar position='fixed'>
@@ -213,7 +215,7 @@ export default function Header({
             </Typography>
           </div>
           <div className='flex flex-1 justify-center items-center'>
-            {user && owner && router.pathname === '/' && (
+            {brFlag && user && owner && router.pathname === '/' && (
               <BibleReference />
             )}
           </div>

--- a/src/components/ScriptureWorkspaceCard.js
+++ b/src/components/ScriptureWorkspaceCard.js
@@ -166,8 +166,10 @@ export default function ScriptureWorkspaceCard({
             onSave={ (bookCode,usfmText) => setDoSave(usfmText) }
             editable={id.endsWith(owner) ? true : false}
             onUnsavedData={(hasUnsavedData) => setUnsavedData(hasUnsavedData)}
-            activeReference={bibleReference}
-            onReferenceSelected={onReferenceSelected}
+            // commenting out this code for v0.9
+            // see issue 152
+            // activeReference={bibleReference}
+            // onReferenceSelected={onReferenceSelected}
           />
         :
         (


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] disables the bible ref component and its syncing and navigation features
- [ ] this is v0.9; the identified shortcoming will be addressed in the v1.0 release

## Test Instructions

- [ ] open multiple books
- [ ] observe that the bible ref component is not present in the page header
- [ ] click a verse in one of the books
- [ ] observe that cards do not sync
