### PR TITLE
Feature cn 158 add button on open book dialog

### DIFF
--- a/src/components/SelectBookPopup.js
+++ b/src/components/SelectBookPopup.js
@@ -78,24 +78,41 @@ export default function SelectBookPopup(
   }
 
   useEffect( () => {
-    if ( selectedOrganization === '' ) {
-      setAddDisabled(true)
-      return
+    console.log("usfmSource=", usfmSource)
+    if ( usfmSource === 'dcs' ) {
+      if ( selectedOrganization === '' ) {
+        setAddDisabled(true)
+        return
+      }
+  
+      if ( selectedBook === null ) {
+        setAddDisabled(true)
+        return
+      }
+  
+      if ( selectedRepository === '' ) {
+        setAddDisabled(true)
+        return
+      }
+  
+      // all inputs are present, make the button active
+      setAddDisabled(false)
+    } else if ( usfmSource === 'url' ) {
+      console.log('Url=',url)
+      if ( url === '' ) {
+        setAddDisabled(true)
+      } else {
+        setAddDisabled(false)
+      }
+    } else if ( usfmSource === 'upload' ) {
+      console.log('uploadedfilename=',uploadedFilename)
+      if ( uploadedFilename === null || uploadedFilename === '' ) {
+        setAddDisabled(true)
+      } else {
+        setAddDisabled(false)
+      }
     }
-
-    if ( selectedBook === null ) {
-      setAddDisabled(true)
-      return
-    }
-
-    if ( selectedRepository === '' ) {
-      setAddDisabled(true)
-      return
-    }
-
-    // all inputs are present, make the button active
-    setAddDisabled(false)
-  }, [selectedOrganization, selectedBook, selectedRepository])
+  }, [usfmSource, selectedOrganization, selectedBook, selectedRepository, url, uploadedFilename])
 
   useEffect( () => {
     setSelectedOrganization(organization)
@@ -103,6 +120,7 @@ export default function SelectBookPopup(
 
   const handleUrlChange = event => {
     setUrl(event.target.value)
+    console.log('handleUrlChange():',event.target.value)
     setFocus('url')
   }
 
@@ -201,7 +219,7 @@ export default function SelectBookPopup(
         variant="outlined"
         startIcon={<UploadFileIcon />}
       >
-        Upload USFM file
+        Upload USFM file {uploadedFilename && '>>"'+uploadedFilename+'"'}
         <input type="file" accept=".usfm" hidden onChange={handleFileUpload} />
       </Button>
       break;
@@ -227,7 +245,12 @@ export default function SelectBookPopup(
           </Select>
         </FormControl>
         <FormControlLabel
-          control={<Checkbox checked={showAll} onChange={(event) => {setShowAll(event.target.checked)}} />}
+          control={<Checkbox checked={showAll} onChange={(event) => {
+            setShowAll(event.target.checked);
+            setSelectedBook(null);
+            setSelectedOrganization('');
+            setSelectedRepository('')
+          }} />}
           label="Show all organizations"
         />
         <FormControl fullWidth margin="normal">

--- a/src/components/SelectBookPopup.js
+++ b/src/components/SelectBookPopup.js
@@ -56,6 +56,7 @@ export default function SelectBookPopup(
       organizationClient,
     }
   } = useContext(AppContext)
+  const [addDisabled, setAddDisabled] = useState(true)
   const [repos, setRepos] = useState([])
   const [selectedRepository, setSelectedRepository] = useState('')
   const [availableBooks, setAvailableBooks] = useState(null)
@@ -75,6 +76,26 @@ export default function SelectBookPopup(
   const handleSourceChange = event => {
     setUsfmSource(event.target.value)
   }
+
+  useEffect( () => {
+    if ( selectedOrganization === '' ) {
+      setAddDisabled(true)
+      return
+    }
+
+    if ( selectedBook === null ) {
+      setAddDisabled(true)
+      return
+    }
+
+    if ( selectedRepository === '' ) {
+      setAddDisabled(true)
+      return
+    }
+
+    // all inputs are present, make the button active
+    setAddDisabled(false)
+  }, [selectedOrganization, selectedBook, selectedRepository])
 
   useEffect( () => {
     setSelectedOrganization(organization)
@@ -281,6 +302,7 @@ export default function SelectBookPopup(
           className='my-3'
           variant='contained'
           onClick={handleClickNext}
+          disabled={addDisabled}
           loadingPosition="start"
           startIcon={<NoteAddIcon />}
         >


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] handles enabling and disabling of the "add" button on the add book popup dialog

## Test Instructions

- [ ] there are three cases, one each for each source.
- [ ] for dcs, the add button should only be enabled when all three pieces are set: org, repo, and book
- [ ] for url, the add button should only be enabled when a non-empty value is entered into the text box
- [ ] for upload, the add button should only be enabled when a file is selected to be uploaded
- [ ] Additionally, when a book is selected for upload, the upload button text should include the filename of the book uploaded
